### PR TITLE
Include a ping event for image processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ocr-service",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ocr-service",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-textract": "^3.465.0",

--- a/src/algorithm-testing/run.js
+++ b/src/algorithm-testing/run.js
@@ -1,0 +1,21 @@
+const path = require("node:path");
+const fs = require("node:fs");
+
+const map = (result) => result.map((b) => {
+    return {
+        text: b.Text,
+        boundingBox: {
+            top: b.Geometry.BoundingBox.Top,
+            left: b.Geometry.BoundingBox.Left,
+            width: b.Geometry.BoundingBox.Width,
+            height: b.Geometry.BoundingBox.Height,
+        },
+        confidence: b.Confidence,
+    };
+});
+
+const filePath = process.argv[2];
+const textractResult = require(filePath);
+const dirname = path.dirname(filePath);
+const ocrResult = JSON.stringify({ textBlocks: map(textractResult.Blocks) }, null, 2);
+fs.writeFileSync(`${dirname}/ocrResult.json`, ocrResult);

--- a/src/functions/images/process/handler.ts
+++ b/src/functions/images/process/handler.ts
@@ -13,6 +13,8 @@ export const main = middyfy(
     SplitsiesFunctionHandlerFactory.create<typeof schema, IExpenseDto>(
         logger,
         async (event) => {
+            if (event.body.pingEvent) return new DataResponse(HttpStatusCode.OK, null).toJson();
+
             const result = await imageService.processImage(event.body.image);
             return new DataResponse(HttpStatusCode.OK, result).toJson();
         },

--- a/src/functions/images/process/schema.ts
+++ b/src/functions/images/process/schema.ts
@@ -1,6 +1,7 @@
 export default {
     type: "object",
     properties: {
+        pingEvent: { type: "boolean" },
         image: { type: "string" }, // base64 encoded image
     },
     required: ["image"],


### PR DESCRIPTION
Allow (authorized) pings to the endpoint to spin up a warm execution environment